### PR TITLE
Add webextention manifest for "theme_experiment"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,12 @@
   "description": "Minimalist, Simple, Keyboard Centered and heavily based on SimpleFox. 🦊",
   "manifest_version": 2,
 
+  "applications": {
+    "gecko": {
+      "id": "cascade@andreas.grafen.info"
+    }
+  },
+
   "theme": {
     "colors": {
       "tab_background_text": "#fbfbfe",

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,63 @@
+{
+  "name": "Cascade",
+  "version": "1.0.0",
+  "description": "Minimalist, Simple, Keyboard Centered and heavily based on SimpleFox. 🦊",
+  "manifest_version": 2,
+
+  "theme": {
+    "colors": {
+      "tab_background_text": "#fbfbfe",
+      "tab_selected": "rgb(43,42,51)",
+      "tab_text": "rgb(251,251,254)",
+      "icons": "rgb(251,251,254)",
+      "frame": "#1c1b22",
+      "popup": "rgb(66,65,77)",
+      "popup_text": "rgb(251,251,254)",
+      "popup_border": "rgb(82,82,94)",
+      "popup_highlight": "rgb(43,42,51)",
+      "tab_line": "transparent",
+      "toolbar": "rgb(43,42,51)",
+      "toolbar_top_separator": "transparent",
+      "toolbar_bottom_separator": "hsl(240, 5%, 5%)",
+      "toolbar_field": "rgb(28,27,34)",
+      "toolbar_field_border": "transparent",
+      "toolbar_field_text": "rgb(251,251,254)",
+      "toolbar_field_focus": "rgb(66,65,77)",
+      "toolbar_text": "rgb(251, 251, 254)",
+      "ntp_background": "rgb(43, 42, 51)",
+      "ntp_card_background": "rgb(66,65,77)",
+      "ntp_text": "rgb(251, 251, 254)",
+      "sidebar": "#38383D",
+      "sidebar_text": "rgb(249, 249, 250)",
+      "sidebar_border": "rgba(255, 255, 255, 0.1)",
+      "button": "rgb(43,42,51)",
+      "button_hover": "rgb(82,82,94)",
+      "button_active": "rgb(91,91,102)",
+      "button_primary": "rgb(0, 221, 255)",
+      "button_primary_hover": "rgb(128, 235, 255)",
+      "button_primary_active": "rgb(170, 242, 255)",
+      "button_primary_color": "rgb(43, 42, 51)",
+      "error_text_color": "rgb(255, 154, 162)",
+      "input_background": "#42414D",
+      "input_color": "rgb(251,251,254)",
+      "input_border": "#8f8f9d",
+      "input_border_error": "rgb(255, 132, 138)",
+      "zoom_controls": "rgb(74,74,85)",
+      "autocomplete_popup_separator": "rgb(82,82,94)",
+      "appmenu_update_icon_color": "#54FFBD",
+      "appmenu_info_icon_color": "#80EBFF",
+      "tab_icon_overlay_stroke": "rgb(66,65,77)",
+      "tab_icon_overlay_fill": "rgb(251,251,254)"
+    },
+    "properties": {
+      "panel_hover": "color-mix(in srgb, currentColor 9%, transparent)",
+      "panel_active": "color-mix(in srgb, currentColor 14%, transparent)",
+      "panel_active_darker": "color-mix(in srgb, currentColor 25%, transparent)",
+      "toolbar_field_icon_opacity": "1",
+      "zap_gradient": "linear-gradient(90deg, #9059FF 0%, #FF4AA2 52.08%, #FFBD4F 100%)"
+    }
+  },
+  "theme_experiment": {
+    "stylesheet": "userChrome.css"
+  }
+}


### PR DESCRIPTION
As discussed on the Pulse Browser Discord, I am working on getting the "theme_experiment" manifest key to work with firefox to make it easier. 

## Build process
To build an unsigned xpi to be shipped you must run:
```sh
sudo npm i -g xpi-creator
xpi-creator ./cascade ./cascade.xpi
```
However, as support for theme_experiment is currently non-existent, there is no reason to need to build it at the moment