### PR TITLE
Add padding to tracking protection icon

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -169,7 +169,10 @@
      #reader-mode-button{ display: none !important; }
 
      /* tracking protection shield icon */
-     #tracking-protection-icon-container { display: none !important; }
+     #tracking-protection-icon-container { 
+        display: none !important;
+	padding-top: 5.8px !important;
+     }
 
      /* #identity-box { display: none !important } /* hides encryption AND permission items */
      #identity-permission-box { display: none !important; } /* only hides permission items */

--- a/userChrome.css
+++ b/userChrome.css
@@ -168,10 +168,10 @@
 
      #reader-mode-button{ display: none !important; }
 
-     /* tracking protection shield icon */
+     /* tracking protection shield icon, change "none" to "inline-block" if you want to see it */
      #tracking-protection-icon-container { 
-        display: none !important;
-	padding-top: 5.8px !important;
+	     display: none !important;
+	     padding-top: 5.8px !important;
      }
 
      /* #identity-box { display: none !important } /* hides encryption AND permission items */


### PR DESCRIPTION
I just added padding for tracking protection icon and also a quick explanation for the ones who wants to unhide it.

Here is a comparison screenshot:

![2022-09-02_18 22 59](https://user-images.githubusercontent.com/42360077/188182138-26e696b4-9df9-40d4-be95-6a521f74e421.png)
