### PR TITLE
feat(UI): Don't darken the personal toolbar for light themes

### DIFF
--- a/chrome/includes/cascade-config-mouse.css
+++ b/chrome/includes/cascade-config-mouse.css
@@ -33,21 +33,24 @@
  +---+---+---+---+---+---+---*/
 
 
+/*  Position of the Personal Toolbar
+ *  possible values:
+ *  0 – toolbar on top
+ *  4 – toolbar on bottom
+ */
 :root {
-
-  /*  Position of the Personal Toolbar
-   *  possible values:
-   *  0 – toolbar on top
-   *  4 – toolbar on bottom
-   */ --uc-toolbar-position: 0;
-
-  /*  Darken the Personal Toolbar by X amount
-   *  where X = 1 means pure black
-   *  and X = 0 means no darkening at all
-   */ --uc-darken-toolbar: .2;
-
+  --uc-toolbar-position: 0;
 }
 
+/*  Darken the Personal Toolbar by X amount
+ *  where X = 1 means pure black
+ *  and X = 0 means no darkening at all
+ */
+@media (prefers-color-scheme: dark) { :root {
+  --uc-darken-toolbar: 0.2;
+}} @media (prefers-color-scheme: light) { :root {
+  --uc-darken-toolbar: 0;
+}}
 
 
 

--- a/chrome/includes/cascade-config.css
+++ b/chrome/includes/cascade-config.css
@@ -37,21 +37,24 @@
  +---+---+---+---+---+---+---*/
 
 
+/*  Position of the Personal Toolbar
+ *  possible values:
+ *  0 – toolbar on top
+ *  4 – toolbar on bottom
+ */
 :root {
-
-  /*  Position of the Personal Toolbar
-   *  possible values:
-   *  0 – toolbar on top
-   *  4 – toolbar on bottom
-   */ --uc-toolbar-position: 0;
-
-  /*  Darken the Personal Toolbar by X amount
-   *  where X = 1 means pure black
-   *  and X = 0 means no darkening at all
-   */ --uc-darken-toolbar: .2;
-
+  --uc-toolbar-position: 0;
 }
 
+/*  Darken the Personal Toolbar by X amount
+ *  where X = 1 means pure black
+ *  and X = 0 means no darkening at all
+ */
+@media (prefers-color-scheme: dark) { :root {
+  --uc-darken-toolbar: 0.2;
+}} @media (prefers-color-scheme: light) { :root {
+  --uc-darken-toolbar: 0;
+}}
 
 
 


### PR DESCRIPTION
Unlike for dark themes—where darkening may even be imperceptible—in most light themes this results in giving the toolbar an off-grey tone.  This is subjectively ugly, and objectively does not fit the chosen theme in most cases.

For example (click to enlarge): 

| Darkened | Not darkened |
|-|-|
| ![2023-01-17-074651_1078x339_scrot](https://user-images.githubusercontent.com/50166980/212829845-d3353ea3-00da-4e37-9a66-2efe9fe80d00.png) | ![2023-01-17-074751_1078x388_scrot](https://user-images.githubusercontent.com/50166980/212829866-2adf1457-d9f4-4ddb-9aad-33cb0ad8bee6.png) |

---

Feel free to close this if it was an intentional design decision.  In that case, one could introduce some documentation in the README, telling users of light themes that this option exist (at least I didn't see anything and finding the right option took me a while :).

N.B.: contributing.md mentions

> - PRs should go to the `dev` branch. Reasons:
>     […]

but there isn't one!