### PR TITLE
Fix tab-center-reborn shadow behavior

### DIFF
--- a/integrations/tabcenter-reborn/tabcenter-reborn.css
+++ b/integrations/tabcenter-reborn/tabcenter-reborn.css
@@ -17,6 +17,7 @@
      --uc-inverted-colour:           #FAFAFC;
      --uc-muted-colour:              #AAAAAC;
      --uc-accent-colour:             var(--uc-identity-colour-purple);
+     --uc-shadow-colour:             #000000;
 
 }
 
@@ -100,7 +101,7 @@ body:hover #tablist-wrapper .tab-title-wrapper {
 [data-identity-color="pink"]      { --identity-color: var(--uc-identity-colour-pink); }
 [data-identity-color="purple"]    { --identity-color: var(--uc-identity-colour-purple); }
 
-.can-scroll-top #tablist { mask: linear-gradient(transparent, black 40px); }
-.can-scroll-bottom #tablist { mask: linear-gradient(black calc(100% - 40px), transparent); }
-.can-scroll-bottom.can-scroll-top #tablist { mask: linear-gradient(transparent, black 40px calc(100% - 40px), transparent); }
+.can-scroll-top #tablist { mask: linear-gradient(transparent, var(--uc-shadow-colour) 40px); }
+.can-scroll-bottom #tablist { mask: linear-gradient(var(--uc-shadow-colour) calc(100% - 40px), transparent); }
+.can-scroll-bottom.can-scroll-top #tablist { mask: linear-gradient(transparent, var(--uc-shadow-colour) 40px calc(100% - 40px), transparent); }
 #topshadow, #bottomshadow { display: none; }

--- a/integrations/tabcenter-reborn/tabcenter-reborn.css
+++ b/integrations/tabcenter-reborn/tabcenter-reborn.css
@@ -100,15 +100,7 @@ body:hover #tablist-wrapper .tab-title-wrapper {
 [data-identity-color="pink"]      { --identity-color: var(--uc-identity-colour-pink); }
 [data-identity-color="purple"]    { --identity-color: var(--uc-identity-colour-purple); }
 
-.can-scroll-top #tablist {
-    mask: linear-gradient(transparent, black 40px);
-}
-.can-scroll-bottom #tablist {
-    mask: linear-gradient(black calc(100% - 40px), transparent);
-}
-.can-scroll-bottom.can-scroll-top #tablist {
-    mask: linear-gradient(transparent, black 40px calc(100% - 40px), transparent);
-}
-#topshadow, #bottomshadow {
-    display: none;
-}
+.can-scroll-top #tablist { mask: linear-gradient(transparent, black 40px); }
+.can-scroll-bottom #tablist { mask: linear-gradient(black calc(100% - 40px), transparent); }
+.can-scroll-bottom.can-scroll-top #tablist { mask: linear-gradient(transparent, black 40px calc(100% - 40px), transparent); }
+#topshadow, #bottomshadow { display: none; }

--- a/integrations/tabcenter-reborn/tabcenter-reborn.css
+++ b/integrations/tabcenter-reborn/tabcenter-reborn.css
@@ -99,3 +99,16 @@ body:hover #tablist-wrapper .tab-title-wrapper {
 [data-identity-color="red"]       { --identity-color: var(--uc-identity-colour-red); }
 [data-identity-color="pink"]      { --identity-color: var(--uc-identity-colour-pink); }
 [data-identity-color="purple"]    { --identity-color: var(--uc-identity-colour-purple); }
+
+.can-scroll-top #tablist {
+    mask: linear-gradient(transparent, black 40px);
+}
+.can-scroll-bottom #tablist {
+    mask: linear-gradient(black calc(100% - 40px), transparent);
+}
+.can-scroll-bottom.can-scroll-top #tablist {
+    mask: linear-gradient(transparent, black 40px calc(100% - 40px), transparent);
+}
+#topshadow, #bottomshadow {
+    display: none;
+}


### PR DESCRIPTION
## Proposed Changes

Previously when I switch to dark mode, tab center reborn would show a weird overflow shadow, like this:

![before](https://user-images.githubusercontent.com/12110829/228751616-165ba0b4-c3f1-43cc-84b2-3e712f4ff4a5.png)

While I'm not entirely sure if this is by design, I was able to find this fix from [ranmaru22/firefox-vertical-tabs](https://github.com/ranmaru22/firefox-vertical-tabs/blob/main/tabCenterReborn.css) and it seems to fit quite nicely.

![after](https://user-images.githubusercontent.com/12110829/228751254-4cef8c1b-05e9-4895-acf7-86977a757902.png)


  -
  -
  -
