### PR TITLE
Fix navbar page action buttons padding

### DIFF
--- a/chrome/includes/cascade-nav-bar.css
+++ b/chrome/includes/cascade-nav-bar.css
@@ -37,3 +37,20 @@
   > .urlbarView-row-inner,
 .urlbarView-row[selected]
   > .urlbarView-row-inner { background: var(--toolbar-field-focus-background-color) !important; }
+
+
+.urlbar-icon, #urlbar-go-button {
+  
+  margin: auto;
+
+}
+
+
+.urlbar-page-action {
+
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+
+}
+
+

--- a/chrome/includes/cascade-nav-bar.css
+++ b/chrome/includes/cascade-nav-bar.css
@@ -39,18 +39,6 @@
   > .urlbarView-row-inner { background: var(--toolbar-field-focus-background-color) !important; }
 
 
-.urlbar-icon, #urlbar-go-button {
-  
-  margin: auto;
+.urlbar-icon, #urlbar-go-button { margin: auto; }
 
-}
-
-
-.urlbar-page-action {
-
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-
-}
-
-
+.urlbar-page-action { padding: 0 inherit !important; }


### PR DESCRIPTION
## Proposed Changes

Again, not sure if this is normal but I'm getting a weird bottom-padding for the buttons to the right side of the navbar, like this:

![before](https://user-images.githubusercontent.com/12110829/228756474-eae32d0d-00fb-45d0-bb44-0629a6efecb6.png)

Ideally this would look like:

![after](https://user-images.githubusercontent.com/12110829/228756550-1b135246-fd75-4ac0-93cd-8de896a965be.png)

  -
  -
  -
