### PR TITLE
Do not hide urlbar buttons

### DIFF
--- a/chrome/includes/cascade-config-mouse.css
+++ b/chrome/includes/cascade-config-mouse.css
@@ -95,8 +95,7 @@
   /* Hides encryption AND permission items */
   /* #identity-box { display: none !important } */
 
-/* Hide everything BUT the zoom indicator within the URL Bar */
-#page-action-buttons > :not(#urlbar-zoom-button):not(#star-button-box) { display: none !important; }
+/* Adjust margin of the urlbar buttons. */
 .urlbar-page-action > image { margin-top: var(--uc-page-action-margin) !important; }
 
 /* Hide Container Tab labels inside the URL bar */


### PR DESCRIPTION
I use extensions that add buttons at this location that I intent to click, for example, awesome-rss.

I did not see any button that would annoy me and that was hidden before.

Removing this rule is enough to restore the buttons. Perhaps that should be an option similar to `--show-tab-close-button-hover` that have a different value in the mouse config than in the default config.