### PR TITLE
Bug Fix: selected tab colour was not applied

### DIFF
--- a/chrome/includes/cascade-tabs.css
+++ b/chrome/includes/cascade-tabs.css
@@ -148,3 +148,9 @@
 #TabsToolbar .tab-icon-overlay:not([crashed])[soundplaying]:hover,
 #TabsToolbar .tab-icon-overlay:not([crashed])[muted]:hover,
 #TabsToolbar .tab-icon-overlay:not([crashed])[activemedia-blocked]:hover { color: var(--toolbar-bgcolor) !important; }
+
+/* selected tab colour fix*/
+.tabbrowser-tab[selected] .tab-content {
+  background-color: var(--uc-highlight-colour) !important;
+}
+


### PR DESCRIPTION
The selected tab colour is the same as that of an unselected tab, thus making it hard to distinguish which one is selected. I assume this to be an unintended feature.
